### PR TITLE
Get port and address from environment variables

### DIFF
--- a/alice4/software/fpgasim/fpgasim/Server.m
+++ b/alice4/software/fpgasim/fpgasim/Server.m
@@ -14,7 +14,8 @@
 #import "device.h"
 #import "driver.h"
 
-#define PORT 25423
+//#define PORT 25423
+short PORT = 25423;
 #define MAX_BUFFER 128
 #define BYTES_PER_VERTEX 12
 
@@ -96,6 +97,11 @@ void handleConnect(CFSocketRef s, CFSocketCallBackType callbackType, CFDataRef a
 
     // Bind the socket.
     struct sockaddr_in sin;
+    
+    if(getenv("PORT") != NULL) {
+        PORT = atoi(getenv("PORT"));
+        printf("PORT = %d\n", PORT);
+    }
 
     memset(&sin, 0, sizeof(sin));
     sin.sin_len = sizeof(sin);

--- a/alice4/software/libgl/network.c
+++ b/alice4/software/libgl/network.c
@@ -19,6 +19,7 @@ static int trace_network = 0;
 static uint8_t buffer[BUFFER_SIZE];
 static int buffer_length = 0;
 
+
 // For connection.h.
 void open_connection() {
     struct sockaddr_in sa;
@@ -33,14 +34,21 @@ void open_connection() {
     memset(&sa, 0, sizeof sa);
 
     sa.sin_family = AF_INET;
-    sa.sin_port = htons(25423);
-    res = inet_pton(AF_INET, "127.0.0.1", &sa.sin_addr);
+    if(getenv("PORT"))
+        sa.sin_port = htons(atoi(getenv("PORT")));
+    else
+        sa.sin_port = htons(25423);
+    if(getenv("ADDR"))
+        res = inet_pton(AF_INET, getenv("ADDR"), &sa.sin_addr);
+    else
+        res = inet_pton(AF_INET, "127.0.0.1", &sa.sin_addr);
 
     if (connect(socket_fd, (struct sockaddr *)&sa, sizeof sa) == -1) {
         perror("connect failed");
         close(socket_fd);
         exit(EXIT_FAILURE);
     }
+
 }
 
 // For connection.h.


### PR DESCRIPTION
Make FPGA simulator listen on a port from environment variable PORT, if set
* This allows two instances of FPGA simulator to coexist and serve separate clients

Make network in libgl connect to address and port from environment variables ADDR and PORT
* This allows two instances of client program to run on the same or separate hosts
* For example, instances of arena could be run on the development Mac and a Linux virtual machine